### PR TITLE
fix: resolve all Zapier integration validation checks for v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zapier-imessage",
-  "version": "1.1.0",
-  "description": "Zapier integration for Photon iMessage server",
+  "version": "1.2.0",
+  "description": "Photon iMessage is a powerful iMessage automation platform that lets you send, receive, and manage iMessages programmatically.",
   "type": "module",
   "main": "dist/index.js",
   "exports": {

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -24,7 +24,7 @@ export default {
       type: "string",
       required: true,
       helpText:
-        "Your Photon iMessage server URL, e.g. https://abc.example.com",
+        "Your Photon iMessage server URL, e.g. `https://abc.example.com`",
     },
     {
       key: "apiKey",
@@ -32,11 +32,24 @@ export default {
       type: "string",
       required: true,
       computed: false,
+      helpText:
+        "Go to your [Photon iMessage Server Dashboard](https://docs.photon.sh) to find your API Key.",
     },
   ],
-  test: {
-    url: "{{bundle.authData.serverUrl}}/api/v1/server/info",
-    method: "GET",
+  test: async (z: any, bundle: any) => {
+    const serverUrl = bundle.authData.serverUrl as string;
+
+    if (!/^https:\/\/[a-zA-Z0-9][a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/.test(serverUrl)) {
+      throw new z.errors.Error(
+        "Server URL must be a valid HTTPS URL (e.g. https://abc.example.com).",
+      );
+    }
+
+    const response = await z.request({
+      url: `${serverUrl}/api/v1/server/info`,
+      method: "GET",
+    });
+    return response.data;
   },
   connectionLabel: "{{bundle.authData.serverUrl}}",
 } satisfies Authentication;

--- a/src/creates/addParticipant.ts
+++ b/src/creates/addParticipant.ts
@@ -11,6 +11,7 @@ const inputFields = defineInputFields([
     type: "string",
     required: true,
     helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "address",
@@ -29,7 +30,8 @@ const perform = (async (z, bundle) => {
     body: { address: bundle.inputData.address },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || `${bundle.inputData.chatGuid}-${bundle.inputData.address}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -45,8 +47,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "participant-add-1234",
       status: 200,
       message: "Participant added successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/createGroupChat.ts
+++ b/src/creates/createGroupChat.ts
@@ -59,7 +59,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || `group-${Date.now()}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -75,9 +76,15 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "iMessage;+;chat123456789",
       guid: "iMessage;+;chat123456789",
       displayName: "New Group",
       participants: ["+1234567890", "+0987654321"],
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "Chat GUID" },
+      { key: "displayName", label: "Display Name" },
+    ],
   },
 });

--- a/src/creates/createPoll.ts
+++ b/src/creates/createPoll.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "title",
@@ -47,7 +48,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || `poll-${Date.now()}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -63,9 +65,15 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "p:0/fake-poll-guid",
       guid: "p:0/fake-poll-guid",
       text: "What should we do?",
       ballotItems: ["Option A", "Option B", "Option C"],
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Poll Question" },
+    ],
   },
 });

--- a/src/creates/deleteChat.ts
+++ b/src/creates/deleteChat.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
 ]);
 
@@ -21,7 +22,8 @@ const perform = (async (z, bundle) => {
     method: "DELETE",
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -37,8 +39,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "delete-chat-1234",
       status: 200,
       message: "Chat deleted successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/editMessage.ts
+++ b/src/creates/editMessage.ts
@@ -51,7 +51,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || bundle.inputData.messageGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -67,9 +68,16 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "p:0/fake-guid-1234",
       guid: "p:0/fake-guid-1234",
       text: "Edited message text",
       dateEdited: 1700000000000,
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Text" },
+      { key: "dateEdited", label: "Date Edited", type: "integer" },
+    ],
   },
 });

--- a/src/creates/markChatRead.ts
+++ b/src/creates/markChatRead.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
 ]);
 
@@ -21,7 +22,8 @@ const perform = (async (z, bundle) => {
     method: "POST",
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -37,8 +39,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "mark-read-1234",
       status: 200,
       message: "Chat marked as read",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/reactMessage.ts
+++ b/src/creates/reactMessage.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "messageGuid",
@@ -49,7 +50,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || `${bundle.inputData.messageGuid}-${bundle.inputData.reaction}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -65,8 +67,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "reaction-1234",
       status: 200,
       message: "Reaction sent successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/removeParticipant.ts
+++ b/src/creates/removeParticipant.ts
@@ -11,6 +11,7 @@ const inputFields = defineInputFields([
     type: "string",
     required: true,
     helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "address",
@@ -29,7 +30,8 @@ const perform = (async (z, bundle) => {
     body: { address: bundle.inputData.address },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || `${bundle.inputData.chatGuid}-${bundle.inputData.address}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -45,8 +47,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "participant-remove-1234",
       status: 200,
       message: "Participant removed successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/renameGroupChat.ts
+++ b/src/creates/renameGroupChat.ts
@@ -11,6 +11,7 @@ const inputFields = defineInputFields([
     type: "string",
     required: true,
     helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "displayName",
@@ -28,7 +29,8 @@ const perform = (async (z, bundle) => {
     body: { displayName: bundle.inputData.displayName },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -44,8 +46,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "iMessage;+;chat123",
       guid: "iMessage;+;chat123",
       displayName: "New Group Name",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "Chat GUID" },
+      { key: "displayName", label: "Display Name" },
+    ],
   },
 });

--- a/src/creates/scheduleMessage.ts
+++ b/src/creates/scheduleMessage.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "message",
@@ -64,7 +65,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: String(data.id || Date.now()), ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -80,10 +82,16 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
-      id: 1,
+      id: "1",
       type: "send-message",
       scheduledFor: 1700000000000,
       status: "scheduled",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "type", label: "Schedule Type" },
+      { key: "scheduledFor", label: "Scheduled For", type: "integer" },
+      { key: "status", label: "Status" },
+    ],
   },
 });

--- a/src/creates/sendAttachment.ts
+++ b/src/creates/sendAttachment.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "fileUrl",
@@ -62,7 +63,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || `${bundle.inputData.chatGuid}-attachment`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -79,8 +81,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "attachment-1234",
       status: 200,
       message: "Attachment sent successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/sendMessage.ts
+++ b/src/creates/sendMessage.ts
@@ -13,6 +13,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "message",
@@ -61,7 +62,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -77,8 +79,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "p:0/sent-guid-1234",
       status: 200,
       message: "Message sent successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/sendSticker.ts
+++ b/src/creates/sendSticker.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "stickerUrl",
@@ -80,7 +81,8 @@ const perform = (async (z, bundle) => {
     body,
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.guid || data.id || `${bundle.inputData.chatGuid}-sticker`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -97,8 +99,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "sticker-1234",
       status: 200,
       message: "Sticker sent successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/setChatBackground.ts
+++ b/src/creates/setChatBackground.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "imageUrl",
@@ -37,7 +38,8 @@ const perform = (async (z, bundle) => {
     body: { fileData: base64 },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -53,8 +55,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "background-1234",
       status: 200,
       message: "Background set successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/setGroupIcon.ts
+++ b/src/creates/setGroupIcon.ts
@@ -11,6 +11,7 @@ const inputFields = defineInputFields([
     type: "string",
     required: true,
     helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "imageUrl",
@@ -36,7 +37,8 @@ const perform = (async (z, bundle) => {
     body: { fileData: base64 },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -52,8 +54,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "icon-1234",
       status: 200,
       message: "Group icon set successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/shareContactCard.ts
+++ b/src/creates/shareContactCard.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
 ]);
 
@@ -25,7 +26,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -42,8 +44,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "contact-card-1234",
       status: 200,
       message: "Contact card shared successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/startTyping.ts
+++ b/src/creates/startTyping.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
 ]);
 
@@ -21,7 +22,8 @@ const perform = (async (z, bundle) => {
     method: "POST",
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.chatGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -37,8 +39,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "typing-1234",
       status: 200,
       message: "Typing indicator started",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/unsendMessage.ts
+++ b/src/creates/unsendMessage.ts
@@ -33,7 +33,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || bundle.inputData.messageGuid, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -49,8 +50,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "unsend-1234",
       status: 200,
       message: "Message unsent successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/creates/votePoll.ts
+++ b/src/creates/votePoll.ts
@@ -12,6 +12,7 @@ const inputFields = defineInputFields([
     required: true,
     helpText:
       "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "pollMessageGuid",
@@ -41,7 +42,8 @@ const perform = (async (z, bundle) => {
     },
   });
 
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return { id: data.id || `${bundle.inputData.pollMessageGuid}-${bundle.inputData.optionIdentifier}`, ...data };
 }) satisfies CreatePerform<typeof inputFields>;
 
 export default defineCreate({
@@ -57,8 +59,14 @@ export default defineCreate({
     inputFields,
     perform,
     sample: {
+      id: "vote-1234",
       status: 200,
       message: "Vote cast successfully",
     },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "status", label: "Status", type: "integer" },
+      { key: "message", label: "Message" },
+    ],
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import packageJson from "../package.json" with { type: "json" };
 
 import authentication, { addApiKeyToHeader } from "./authentication.js";
 import newMessage from "./triggers/newMessage.js";
+import listChats from "./triggers/listChats.js";
 import sendMessage from "./creates/sendMessage.js";
 import scheduleMessage from "./creates/scheduleMessage.js";
 import reactMessage from "./creates/reactMessage.js";
@@ -54,6 +55,10 @@ export default defineApp({
   version: packageJson.version,
   platformVersion,
 
+  flags: {
+    cleanInputData: false,
+  },
+
   authentication,
 
   beforeRequest: [addApiKeyToHeader],
@@ -61,6 +66,7 @@ export default defineApp({
 
   triggers: {
     [newMessage.key]: newMessage,
+    [listChats.key]: listChats,
   },
 
   creates: {

--- a/src/searches/findMessages.ts
+++ b/src/searches/findMessages.ts
@@ -24,6 +24,7 @@ const inputFields = defineInputFields([
     label: "Chat GUID (optional)",
     type: "string",
     required: false,
+    dynamic: "list_chats.id.displayName",
   },
   {
     key: "limit",

--- a/src/searches/getChatParticipants.ts
+++ b/src/searches/getChatParticipants.ts
@@ -11,6 +11,7 @@ const inputFields = defineInputFields([
     type: "string",
     required: true,
     helpText: "The chat GUID, e.g. iMessage;+;chat123 for a group",
+    dynamic: "list_chats.id.displayName",
   },
 ]);
 

--- a/src/triggers/listChats.ts
+++ b/src/triggers/listChats.ts
@@ -1,0 +1,52 @@
+import {
+  defineTrigger,
+  type PollingTriggerPerform,
+} from "zapier-platform-core";
+
+interface ChatResult {
+  guid: string;
+  chatIdentifier: string;
+  displayName: string | null;
+  style: number;
+}
+
+const perform = (async (z, bundle) => {
+  const response = await z.request<ChatResult[]>({
+    url: `${bundle.authData.serverUrl}/api/v1/chat/query`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: { limit: 50, offset: 0, sort: "lastmessage" },
+  });
+
+  const chats: ChatResult[] =
+    (response.data as unknown as { data?: ChatResult[] })?.data ??
+    (response.data as unknown as ChatResult[]) ??
+    [];
+
+  return chats.map((chat) => ({
+    id: chat.guid,
+    chatIdentifier: chat.chatIdentifier,
+    displayName: chat.displayName || chat.chatIdentifier,
+  }));
+}) satisfies PollingTriggerPerform;
+
+export default defineTrigger({
+  key: "list_chats",
+  noun: "Chat",
+
+  display: {
+    label: "List Chats",
+    description: "Triggers when listing chats for dynamic dropdowns.",
+    hidden: true,
+  },
+
+  operation: {
+    type: "polling",
+    perform,
+    sample: {
+      id: "iMessage;-;+11234567890",
+      chatIdentifier: "+11234567890",
+      displayName: "+11234567890",
+    },
+  },
+});

--- a/src/triggers/newMessage.ts
+++ b/src/triggers/newMessage.ts
@@ -56,7 +56,7 @@ export default defineTrigger({
   display: {
     label: "New Message Received",
     description:
-      "Triggers when a new iMessage is received on your Photon server.",
+      "Triggers when a new iMessage is received on your Photon iMessage server.",
   },
 
   operation: {


### PR DESCRIPTION
## Summary
- Add `id` field to all create/action samples and perform returns for D010/T002 primary key compliance
- Add `outputFields` to all creates missing field definitions  
- Add hidden `list_chats` trigger for dynamic dropdown support on `chatGuid` fields (D004/D005)
- Set global `cleanInputData: false` flag (D028)
- Add help text link for API key auth field (D002)
- Add domain validation in auth test function (D026)
- Update trigger description wording and package description (M002)
- Bump version to 1.2.0

## Validation Results
- **25 checks passed**, 0 errors, 0 publishing task failures
- 7 remaining non-blocking warnings (D004 for message GUIDs that can't have dropdowns, D026 for serverUrl)

## Test plan
- [x] `npm run build` succeeds
- [x] `zapier validate` passes with 0 errors and 0 publishing task failures
- [ ] `zapier push` to deploy v1.2.0
- [ ] Create live Zaps for each trigger/search/action
- [ ] Connect at least 3 accounts with live Zaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New chat list trigger enables dynamic dropdown selection across operations for improved workflow efficiency.
  * Enhanced authentication with URL validation and additional guidance for API key setup.

* **Improvements**
  * Standardized operation responses with consistent ID handling and explicit output field definitions across all actions.
  * Clarified product description to emphasize iMessage automation platform functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->