### PR TITLE
feat: add instant webhook trigger via Photon Webhook Bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-imessage",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Photon iMessage is a powerful iMessage automation platform that lets you send, receive, and manage iMessages programmatically.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -119,6 +119,15 @@ const authentication: Authentication = {
       helpText:
         "Go to your [Photon iMessage Server Dashboard](https://docs.photon.sh) to find your API Key.",
     },
+    {
+      key: "webhookBridgeUrl",
+      label: "Webhook Bridge URL",
+      type: "string",
+      required: false,
+      helpText:
+        "URL of your Photon Webhook Bridge for instant triggers, e.g. `https://webhook.photon.codes`. " +
+        "Leave blank if you only need polling triggers.",
+    },
   ],
   // Use a function perform so we control URL normalisation and error messages.
   test: authTest,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import packageJson from "../package.json" with { type: "json" };
 
 import authentication, { addApiKeyToHeader } from "./authentication.js";
 import newMessage from "./triggers/newMessage.js";
+import newMessageInstant from "./triggers/newMessageInstant.js";
 import listChats from "./triggers/listChats.js";
 import sendMessage from "./creates/sendMessage.js";
 import scheduleMessage from "./creates/scheduleMessage.js";
@@ -72,6 +73,7 @@ export default defineApp({
 
   triggers: {
     [newMessage.key]: newMessage,
+    [newMessageInstant.key]: newMessageInstant,
     [listChats.key]: listChats,
   },
 

--- a/src/triggers/newMessageInstant.ts
+++ b/src/triggers/newMessageInstant.ts
@@ -1,0 +1,166 @@
+import {
+  defineTrigger,
+  type WebhookTriggerPerform,
+  type WebhookTriggerPerformList,
+  type WebhookTriggerPerformSubscribe,
+  type WebhookTriggerPerformUnsubscribe,
+} from "zapier-platform-core";
+import { normalizeUrl } from "../authentication.js";
+
+const WEBHOOK_BRIDGE_EVENT = "new-message";
+
+const performSubscribe = (async (z, bundle) => {
+  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
+  if (!bridgeUrl) {
+    throw new z.errors.Error(
+      "Webhook Bridge URL is required for instant triggers. " +
+        "Please update your Photon iMessage connection and provide the Webhook Bridge URL.",
+      "ConfigurationError",
+    );
+  }
+
+  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+  const response = await z.request({
+    url: `${bridgeUrl}/api/webhooks`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {
+      serverUrl,
+      apiKey: bundle.authData.apiKey,
+      webhookUrl: bundle.targetUrl,
+    },
+  });
+
+  return response.data as { id: string; signingSecret: string };
+}) satisfies WebhookTriggerPerformSubscribe;
+
+const performUnsubscribe = (async (z, bundle) => {
+  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
+  if (!bridgeUrl || !bundle.subscribeData?.id) {
+    return {};
+  }
+
+  await z.request({
+    url: `${bridgeUrl}/api/webhooks/${bundle.subscribeData.id}`,
+    method: "DELETE",
+  });
+
+  return {};
+}) satisfies WebhookTriggerPerformUnsubscribe;
+
+/**
+ * Processes the inbound webhook payload from the Photon Webhook Bridge.
+ * Payload shape: { event: string, data: { ... } }
+ */
+const perform = (async (_z, bundle) => {
+  const payload = bundle.cleanedRequest as {
+    event?: string;
+    data?: Record<string, unknown>;
+  };
+
+  if (!payload?.data) {
+    return [];
+  }
+
+  if (payload.event !== WEBHOOK_BRIDGE_EVENT) {
+    return [];
+  }
+
+  const msg = payload.data;
+  return [
+    {
+      id: (msg.guid as string) || `hook-${Date.now()}`,
+      guid: msg.guid,
+      text: msg.text,
+      sender:
+        (msg.handle as Record<string, unknown>)?.address ?? msg.senderAddress,
+      chatGuid:
+        Array.isArray(msg.chats) && msg.chats.length > 0
+          ? msg.chats[0]
+          : msg.chatGuid,
+      dateCreated: msg.dateCreated,
+      isFromMe: msg.isFromMe ?? false,
+      hasAttachments: Array.isArray(msg.attachments)
+        ? msg.attachments.length > 0
+        : false,
+    },
+  ];
+}) satisfies WebhookTriggerPerform;
+
+/**
+ * Fallback polling used during Zap setup so the user can load test data
+ * without waiting for a live webhook event.
+ */
+const performList = (async (z, bundle) => {
+  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+  const response = await z.request<{
+    data?: Array<{
+      guid: string;
+      text: string;
+      handle?: { address: string };
+      chats?: string[];
+      dateCreated: number;
+      isFromMe: boolean;
+      attachments?: unknown[];
+    }>;
+  }>({
+    url: `${serverUrl}/api/v1/message/query`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: { sort: "DESC", limit: 10 },
+  });
+
+  const messages = response.data?.data ?? [];
+  return messages
+    .filter((msg) => !msg.isFromMe)
+    .map((msg) => ({
+      id: msg.guid,
+      guid: msg.guid,
+      text: msg.text,
+      sender: msg.handle?.address,
+      chatGuid: msg.chats?.[0],
+      dateCreated: msg.dateCreated,
+      isFromMe: msg.isFromMe,
+      hasAttachments: (msg.attachments?.length ?? 0) > 0,
+    }));
+}) satisfies WebhookTriggerPerformList;
+
+export default defineTrigger({
+  key: "new_message_instant",
+  noun: "Message",
+
+  display: {
+    label: "New Message Received (Instant)",
+    description:
+      "Triggers when a new iMessage is received instantly via the Photon Webhook Bridge.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe,
+    performUnsubscribe,
+
+    sample: {
+      id: "p:0/fake-guid-1234",
+      guid: "p:0/fake-guid-1234",
+      text: "Hello from iMessage!",
+      sender: "+11234567890",
+      chatGuid: "iMessage;-;+11234567890",
+      dateCreated: 1700000000000,
+      isFromMe: false,
+      hasAttachments: false,
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Text" },
+      { key: "sender", label: "Sender" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "dateCreated", label: "Date Created", type: "integer" },
+      { key: "isFromMe", label: "Is From Me", type: "boolean" },
+      { key: "hasAttachments", label: "Has Attachments", type: "boolean" },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a new **"New Message Received (Instant)"** REST Hook trigger (`new_message_instant`) powered by the [Photon Webhook Bridge](https://github.com/photon-hq/webhook)
- Adds an optional `webhookBridgeUrl` authentication field so users can provide their webhook bridge endpoint
- When a Zap is turned on, Zapier calls `POST /api/webhooks` on the bridge to subscribe; when turned off, it calls `DELETE /api/webhooks/:id` to unsubscribe
- Includes a `performList` fallback that polls the iMessage server for test data during Zap setup
- Version bumped to **1.4.0** and pushed to Zapier

## Test plan
- [ ] Connect an account with a valid Webhook Bridge URL
- [ ] Create a Zap using the "New Message Received (Instant)" trigger
- [ ] Verify subscription is created on the webhook bridge
- [ ] Send a test iMessage and verify the Zap triggers instantly
- [ ] Turn off the Zap and verify the subscription is removed
- [ ] Verify the polling "New Message Received" trigger still works independently