### PR TITLE
feat: full webhook trigger suite — v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-imessage",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "description": "Photon iMessage is a powerful iMessage automation platform that lets you send, receive, and manage iMessages programmatically.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -123,10 +123,9 @@ const authentication: Authentication = {
       key: "webhookBridgeUrl",
       label: "Webhook Bridge URL",
       type: "string",
-      required: false,
+      required: true,
       helpText:
-        "URL of your Photon Webhook Bridge for instant triggers, e.g. `https://webhook.photon.codes`. " +
-        "Leave blank if you only need polling triggers.",
+        "URL of your Photon Webhook Bridge, e.g. `https://webhook.photon.codes`.",
     },
   ],
   // Use a function perform so we control URL normalisation and error messages.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,28 @@ import type { AfterResponseMiddleware } from "zapier-platform-core";
 import packageJson from "../package.json" with { type: "json" };
 
 import authentication, { addApiKeyToHeader } from "./authentication.js";
-import newMessage from "./triggers/newMessage.js";
+
+// Instant (webhook) triggers — primary
 import newMessageInstant from "./triggers/newMessageInstant.js";
+import messageUpdatedInstant from "./triggers/messageUpdatedInstant.js";
+import messageSendErrorInstant from "./triggers/messageSendErrorInstant.js";
+import typingIndicatorInstant from "./triggers/typingIndicatorInstant.js";
+import chatReadStatusInstant from "./triggers/chatReadStatusInstant.js";
+import groupNameChangeInstant from "./triggers/groupNameChangeInstant.js";
+import participantAddedInstant from "./triggers/participantAddedInstant.js";
+import participantRemovedInstant from "./triggers/participantRemovedInstant.js";
+import participantLeftInstant from "./triggers/participantLeftInstant.js";
+import groupIconChangedInstant from "./triggers/groupIconChangedInstant.js";
+import scheduledMessageInstant from "./triggers/scheduledMessageInstant.js";
+import findMyLocationInstant from "./triggers/findMyLocationInstant.js";
+import ftCallStatusInstant from "./triggers/ftCallStatusInstant.js";
+import serverUpdateInstant from "./triggers/serverUpdateInstant.js";
+
+// Polling triggers — secondary / hidden
+import newMessage from "./triggers/newMessage.js";
 import listChats from "./triggers/listChats.js";
+
+// Creates
 import sendMessage from "./creates/sendMessage.js";
 import scheduleMessage from "./creates/scheduleMessage.js";
 import reactMessage from "./creates/reactMessage.js";
@@ -28,6 +47,8 @@ import votePoll from "./creates/votePoll.js";
 import shareContactCard from "./creates/shareContactCard.js";
 import setChatBackground from "./creates/setChatBackground.js";
 import setGroupIcon from "./creates/setGroupIcon.js";
+
+// Searches
 import findMessages from "./searches/findMessages.js";
 import getChats from "./searches/getChats.js";
 import getChatParticipants from "./searches/getChatParticipants.js";
@@ -39,8 +60,6 @@ import findMyFriends from "./searches/findMyFriends.js";
 
 const handleErrors: AfterResponseMiddleware = (response, z) => {
   if (response.status >= 400) {
-    // Produce a readable body even when response.data is undefined (e.g. the
-    // server returned an empty body or non-JSON for a 4xx response).
     let body: string;
     if (typeof response.data === "string") {
       body = response.data || response.content || "(empty body)";
@@ -72,8 +91,24 @@ export default defineApp({
   afterResponse: [handleErrors],
 
   triggers: {
-    [newMessage.key]: newMessage,
+    // Instant (webhook) triggers — shown to users
     [newMessageInstant.key]: newMessageInstant,
+    [messageUpdatedInstant.key]: messageUpdatedInstant,
+    [messageSendErrorInstant.key]: messageSendErrorInstant,
+    [typingIndicatorInstant.key]: typingIndicatorInstant,
+    [chatReadStatusInstant.key]: chatReadStatusInstant,
+    [groupNameChangeInstant.key]: groupNameChangeInstant,
+    [participantAddedInstant.key]: participantAddedInstant,
+    [participantRemovedInstant.key]: participantRemovedInstant,
+    [participantLeftInstant.key]: participantLeftInstant,
+    [groupIconChangedInstant.key]: groupIconChangedInstant,
+    [scheduledMessageInstant.key]: scheduledMessageInstant,
+    [findMyLocationInstant.key]: findMyLocationInstant,
+    [ftCallStatusInstant.key]: ftCallStatusInstant,
+    [serverUpdateInstant.key]: serverUpdateInstant,
+
+    // Polling fallback (hidden)
+    [newMessage.key]: newMessage,
     [listChats.key]: listChats,
   },
 

--- a/src/triggers/chatReadStatusInstant.ts
+++ b/src/triggers/chatReadStatusInstant.ts
@@ -1,0 +1,47 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "read-iMessage;-;+11234567890-1700000000000",
+    chatGuid: "iMessage;-;+11234567890",
+    isRead: true,
+  },
+];
+
+const perform = makePerform("chat-read-status-changed", (data) => ({
+  id: `read-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  isRead: data.isRead ?? data.read,
+}));
+
+export default defineTrigger({
+  key: "chat_read_status_instant",
+  noun: "Read Status",
+
+  display: {
+    label: "Chat Read Status Changed (Instant)",
+    description:
+      "Triggers when a chat's read status changes on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "read-iMessage;-;+11234567890-1700000000000",
+      chatGuid: "iMessage;-;+11234567890",
+      isRead: true,
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "isRead", label: "Is Read", type: "boolean" },
+    ],
+  },
+});

--- a/src/triggers/findMyLocationInstant.ts
+++ b/src/triggers/findMyLocationInstant.ts
@@ -1,0 +1,59 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "loc-friend-1234",
+    name: "John Doe",
+    latitude: 37.7749,
+    longitude: -122.4194,
+    address: "San Francisco, CA",
+    timestamp: 1700000000000,
+  },
+];
+
+const perform = makePerform("new-findmy-location", (data) => ({
+  id: (data.id as string) || `loc-${Date.now()}`,
+  name: data.name,
+  latitude: data.latitude ?? data.lat,
+  longitude: data.longitude ?? data.lng ?? data.lon,
+  address: data.address,
+  timestamp: data.timestamp ?? data.lastUpdated,
+}));
+
+export default defineTrigger({
+  key: "findmy_location_instant",
+  noun: "Location",
+
+  display: {
+    label: "Find My Location Updated (Instant)",
+    description:
+      "Triggers when a Find My Friends location is updated on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "loc-friend-1234",
+      name: "John Doe",
+      latitude: 37.7749,
+      longitude: -122.4194,
+      address: "San Francisco, CA",
+      timestamp: 1700000000000,
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "name", label: "Name" },
+      { key: "latitude", label: "Latitude", type: "number" },
+      { key: "longitude", label: "Longitude", type: "number" },
+      { key: "address", label: "Address" },
+      { key: "timestamp", label: "Timestamp", type: "integer" },
+    ],
+  },
+});

--- a/src/triggers/ftCallStatusInstant.ts
+++ b/src/triggers/ftCallStatusInstant.ts
@@ -1,0 +1,51 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "ftcall-iMessage;-;+11234567890-1700000000000",
+    chatGuid: "iMessage;-;+11234567890",
+    status: "ringing",
+    caller: "+11234567890",
+  },
+];
+
+const perform = makePerform("ft-call-status-changed", (data) => ({
+  id: `ftcall-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  status: data.status,
+  caller: (data.handle as Record<string, unknown>)?.address ?? data.caller,
+}));
+
+export default defineTrigger({
+  key: "ft_call_status_instant",
+  noun: "FaceTime Call",
+
+  display: {
+    label: "FaceTime Call Status Changed (Instant)",
+    description:
+      "Triggers when a FaceTime call status changes on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "ftcall-iMessage;-;+11234567890-1700000000000",
+      chatGuid: "iMessage;-;+11234567890",
+      status: "ringing",
+      caller: "+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "status", label: "Status" },
+      { key: "caller", label: "Caller" },
+    ],
+  },
+});

--- a/src/triggers/groupIconChangedInstant.ts
+++ b/src/triggers/groupIconChangedInstant.ts
@@ -1,0 +1,43 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "gicon-iMessage;+;chat123-1700000000000",
+    chatGuid: "iMessage;+;chat123",
+  },
+];
+
+const perform = makePerform("group-icon-changed", (data) => ({
+  id: `gicon-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+}));
+
+export default defineTrigger({
+  key: "group_icon_changed_instant",
+  noun: "Group Icon",
+
+  display: {
+    label: "Group Icon Changed (Instant)",
+    description:
+      "Triggers when a group chat icon is changed on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "gicon-iMessage;+;chat123-1700000000000",
+      chatGuid: "iMessage;+;chat123",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+    ],
+  },
+});

--- a/src/triggers/groupNameChangeInstant.ts
+++ b/src/triggers/groupNameChangeInstant.ts
@@ -1,0 +1,51 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "grpname-iMessage;+;chat123-1700000000000",
+    chatGuid: "iMessage;+;chat123",
+    newName: "New Group Name",
+    oldName: "Old Group Name",
+  },
+];
+
+const perform = makePerform("group-name-change", (data) => ({
+  id: `grpname-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  newName: data.newName ?? data.displayName,
+  oldName: data.oldName,
+}));
+
+export default defineTrigger({
+  key: "group_name_change_instant",
+  noun: "Group Name",
+
+  display: {
+    label: "Group Name Changed (Instant)",
+    description:
+      "Triggers when a group chat is renamed on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "grpname-iMessage;+;chat123-1700000000000",
+      chatGuid: "iMessage;+;chat123",
+      newName: "New Group Name",
+      oldName: "Old Group Name",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "newName", label: "New Name" },
+      { key: "oldName", label: "Old Name" },
+    ],
+  },
+});

--- a/src/triggers/messageSendErrorInstant.ts
+++ b/src/triggers/messageSendErrorInstant.ts
@@ -1,0 +1,57 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "p:0/error-guid-1234",
+    guid: "p:0/error-guid-1234",
+    text: "Failed message",
+    error: "Network timeout",
+    chatGuid: "iMessage;-;+11234567890",
+  },
+];
+
+const perform = makePerform("message-send-error", (data) => ({
+  id: (data.guid as string) || (data.tempGuid as string) || `err-${Date.now()}`,
+  guid: data.guid ?? data.tempGuid,
+  text: data.text,
+  error: data.error ?? data.message,
+  chatGuid: Array.isArray(data.chats) && data.chats.length > 0
+    ? data.chats[0]
+    : data.chatGuid,
+}));
+
+export default defineTrigger({
+  key: "message_send_error_instant",
+  noun: "Error",
+
+  display: {
+    label: "Message Send Error (Instant)",
+    description:
+      "Triggers when an iMessage fails to send on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "p:0/error-guid-1234",
+      guid: "p:0/error-guid-1234",
+      text: "Failed message",
+      error: "Network timeout",
+      chatGuid: "iMessage;-;+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Text" },
+      { key: "error", label: "Error Message" },
+      { key: "chatGuid", label: "Chat GUID" },
+    ],
+  },
+});

--- a/src/triggers/messageUpdatedInstant.ts
+++ b/src/triggers/messageUpdatedInstant.ts
@@ -1,0 +1,67 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "p:0/fake-guid-1234",
+    guid: "p:0/fake-guid-1234",
+    text: "Edited message text",
+    sender: "+11234567890",
+    chatGuid: "iMessage;-;+11234567890",
+    dateCreated: 1700000000000,
+    isFromMe: false,
+  },
+];
+
+const perform = makePerform("updated-message", (msg) => ({
+  id: (msg.guid as string) || `hook-${Date.now()}`,
+  guid: msg.guid,
+  text: msg.text,
+  sender:
+    (msg.handle as Record<string, unknown>)?.address ?? msg.senderAddress,
+  chatGuid:
+    Array.isArray(msg.chats) && msg.chats.length > 0
+      ? msg.chats[0]
+      : msg.chatGuid,
+  dateCreated: msg.dateCreated,
+  isFromMe: msg.isFromMe ?? false,
+}));
+
+export default defineTrigger({
+  key: "message_updated_instant",
+  noun: "Message",
+
+  display: {
+    label: "Message Updated (Instant)",
+    description:
+      "Triggers when an iMessage is edited or updated on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "p:0/fake-guid-1234",
+      guid: "p:0/fake-guid-1234",
+      text: "Edited message text",
+      sender: "+11234567890",
+      chatGuid: "iMessage;-;+11234567890",
+      dateCreated: 1700000000000,
+      isFromMe: false,
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Text" },
+      { key: "sender", label: "Sender" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "dateCreated", label: "Date Created", type: "integer" },
+      { key: "isFromMe", label: "Is From Me", type: "boolean" },
+    ],
+  },
+});

--- a/src/triggers/newMessage.ts
+++ b/src/triggers/newMessage.ts
@@ -54,9 +54,10 @@ export default defineTrigger({
   noun: "Message",
 
   display: {
-    label: "New Message Received",
+    label: "New Message Received (Polling)",
     description:
-      "Triggers when a new iMessage is received on your Photon iMessage server.",
+      "Triggers when a new iMessage is received on your Photon iMessage server via polling.",
+    hidden: true,
   },
 
   operation: {

--- a/src/triggers/newMessageInstant.ts
+++ b/src/triggers/newMessageInstant.ts
@@ -1,96 +1,27 @@
 import {
   defineTrigger,
-  type WebhookTriggerPerform,
   type WebhookTriggerPerformList,
-  type WebhookTriggerPerformSubscribe,
-  type WebhookTriggerPerformUnsubscribe,
 } from "zapier-platform-core";
 import { normalizeUrl } from "../authentication.js";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
 
-const WEBHOOK_BRIDGE_EVENT = "new-message";
+const perform = makePerform("new-message", (msg) => ({
+  id: (msg.guid as string) || `hook-${Date.now()}`,
+  guid: msg.guid,
+  text: msg.text,
+  sender:
+    (msg.handle as Record<string, unknown>)?.address ?? msg.senderAddress,
+  chatGuid:
+    Array.isArray(msg.chats) && msg.chats.length > 0
+      ? msg.chats[0]
+      : msg.chatGuid,
+  dateCreated: msg.dateCreated,
+  isFromMe: msg.isFromMe ?? false,
+  hasAttachments: Array.isArray(msg.attachments)
+    ? msg.attachments.length > 0
+    : false,
+}));
 
-const performSubscribe = (async (z, bundle) => {
-  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
-  if (!bridgeUrl) {
-    throw new z.errors.Error(
-      "Webhook Bridge URL is required for instant triggers. " +
-        "Please update your Photon iMessage connection and provide the Webhook Bridge URL.",
-      "ConfigurationError",
-    );
-  }
-
-  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
-  const response = await z.request({
-    url: `${bridgeUrl}/api/webhooks`,
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: {
-      serverUrl,
-      apiKey: bundle.authData.apiKey,
-      webhookUrl: bundle.targetUrl,
-    },
-  });
-
-  return response.data as { id: string; signingSecret: string };
-}) satisfies WebhookTriggerPerformSubscribe;
-
-const performUnsubscribe = (async (z, bundle) => {
-  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
-  if (!bridgeUrl || !bundle.subscribeData?.id) {
-    return {};
-  }
-
-  await z.request({
-    url: `${bridgeUrl}/api/webhooks/${bundle.subscribeData.id}`,
-    method: "DELETE",
-  });
-
-  return {};
-}) satisfies WebhookTriggerPerformUnsubscribe;
-
-/**
- * Processes the inbound webhook payload from the Photon Webhook Bridge.
- * Payload shape: { event: string, data: { ... } }
- */
-const perform = (async (_z, bundle) => {
-  const payload = bundle.cleanedRequest as {
-    event?: string;
-    data?: Record<string, unknown>;
-  };
-
-  if (!payload?.data) {
-    return [];
-  }
-
-  if (payload.event !== WEBHOOK_BRIDGE_EVENT) {
-    return [];
-  }
-
-  const msg = payload.data;
-  return [
-    {
-      id: (msg.guid as string) || `hook-${Date.now()}`,
-      guid: msg.guid,
-      text: msg.text,
-      sender:
-        (msg.handle as Record<string, unknown>)?.address ?? msg.senderAddress,
-      chatGuid:
-        Array.isArray(msg.chats) && msg.chats.length > 0
-          ? msg.chats[0]
-          : msg.chatGuid,
-      dateCreated: msg.dateCreated,
-      isFromMe: msg.isFromMe ?? false,
-      hasAttachments: Array.isArray(msg.attachments)
-        ? msg.attachments.length > 0
-        : false,
-    },
-  ];
-}) satisfies WebhookTriggerPerform;
-
-/**
- * Fallback polling used during Zap setup so the user can load test data
- * without waiting for a live webhook event.
- */
 const performList = (async (z, bundle) => {
   const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
   const response = await z.request<{
@@ -139,8 +70,8 @@ export default defineTrigger({
     type: "hook",
     perform,
     performList,
-    performSubscribe,
-    performUnsubscribe,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
 
     sample: {
       id: "p:0/fake-guid-1234",

--- a/src/triggers/participantAddedInstant.ts
+++ b/src/triggers/participantAddedInstant.ts
@@ -1,0 +1,48 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "padd-iMessage;+;chat123-1700000000000",
+    chatGuid: "iMessage;+;chat123",
+    participant: "+11234567890",
+  },
+];
+
+const perform = makePerform("participant-added", (data) => ({
+  id: `padd-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  participant:
+    (data.handle as Record<string, unknown>)?.address ?? data.participant,
+}));
+
+export default defineTrigger({
+  key: "participant_added_instant",
+  noun: "Participant",
+
+  display: {
+    label: "Participant Added (Instant)",
+    description:
+      "Triggers when a participant is added to a group chat on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "padd-iMessage;+;chat123-1700000000000",
+      chatGuid: "iMessage;+;chat123",
+      participant: "+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "participant", label: "Participant" },
+    ],
+  },
+});

--- a/src/triggers/participantLeftInstant.ts
+++ b/src/triggers/participantLeftInstant.ts
@@ -1,0 +1,48 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "pleft-iMessage;+;chat123-1700000000000",
+    chatGuid: "iMessage;+;chat123",
+    participant: "+11234567890",
+  },
+];
+
+const perform = makePerform("participant-left", (data) => ({
+  id: `pleft-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  participant:
+    (data.handle as Record<string, unknown>)?.address ?? data.participant,
+}));
+
+export default defineTrigger({
+  key: "participant_left_instant",
+  noun: "Participant",
+
+  display: {
+    label: "Participant Left (Instant)",
+    description:
+      "Triggers when a participant leaves a group chat on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "pleft-iMessage;+;chat123-1700000000000",
+      chatGuid: "iMessage;+;chat123",
+      participant: "+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "participant", label: "Participant" },
+    ],
+  },
+});

--- a/src/triggers/participantRemovedInstant.ts
+++ b/src/triggers/participantRemovedInstant.ts
@@ -1,0 +1,48 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "prem-iMessage;+;chat123-1700000000000",
+    chatGuid: "iMessage;+;chat123",
+    participant: "+11234567890",
+  },
+];
+
+const perform = makePerform("participant-removed", (data) => ({
+  id: `prem-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  participant:
+    (data.handle as Record<string, unknown>)?.address ?? data.participant,
+}));
+
+export default defineTrigger({
+  key: "participant_removed_instant",
+  noun: "Participant",
+
+  display: {
+    label: "Participant Removed (Instant)",
+    description:
+      "Triggers when a participant is removed from a group chat on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "prem-iMessage;+;chat123-1700000000000",
+      chatGuid: "iMessage;+;chat123",
+      participant: "+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "participant", label: "Participant" },
+    ],
+  },
+});

--- a/src/triggers/scheduledMessageInstant.ts
+++ b/src/triggers/scheduledMessageInstant.ts
@@ -1,0 +1,90 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "sched-guid-1234",
+    event: "scheduled-message-created",
+    guid: "sched-guid-1234",
+    text: "Reminder: meeting at 3pm",
+    chatGuid: "iMessage;-;+11234567890",
+    scheduledDate: 1700100000000,
+    error: null,
+  },
+];
+
+const SCHEDULED_EVENTS = new Set([
+  "scheduled-message-created",
+  "scheduled-message-updated",
+  "scheduled-message-deleted",
+  "scheduled-message-sent",
+  "scheduled-message-error",
+]);
+
+const perform = async (
+  _z: import("zapier-platform-core").ZObject,
+  bundle: import("zapier-platform-core").Bundle,
+) => {
+  const payload = bundle.cleanedRequest as {
+    event?: string;
+    data?: Record<string, unknown>;
+  };
+
+  if (!payload?.data || !payload.event || !SCHEDULED_EVENTS.has(payload.event)) {
+    return [];
+  }
+
+  const d = payload.data;
+  return [
+    {
+      id: (d.guid as string) || (d.id as string) || `sched-${Date.now()}`,
+      event: payload.event,
+      guid: d.guid ?? d.id,
+      text: d.text,
+      chatGuid: Array.isArray(d.chats) && d.chats.length > 0
+        ? d.chats[0]
+        : d.chatGuid,
+      scheduledDate: d.scheduledDate ?? d.scheduledAt,
+      error: d.error,
+    },
+  ];
+};
+
+export default defineTrigger({
+  key: "scheduled_message_instant",
+  noun: "Scheduled Message",
+
+  display: {
+    label: "Scheduled Message Event (Instant)",
+    description:
+      "Triggers when a scheduled message is created, updated, sent, deleted, or errors on your Photon server.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "sched-guid-1234",
+      event: "scheduled-message-created",
+      guid: "sched-guid-1234",
+      text: "Reminder: meeting at 3pm",
+      chatGuid: "iMessage;-;+11234567890",
+      scheduledDate: 1700100000000,
+      error: null,
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "event", label: "Event Type" },
+      { key: "guid", label: "GUID" },
+      { key: "text", label: "Text" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "scheduledDate", label: "Scheduled Date", type: "integer" },
+      { key: "error", label: "Error" },
+    ],
+  },
+});

--- a/src/triggers/serverUpdateInstant.ts
+++ b/src/triggers/serverUpdateInstant.ts
@@ -1,0 +1,76 @@
+import { defineTrigger } from "zapier-platform-core";
+import { subscribe, unsubscribe } from "./webhookHelpers.js";
+import type { ZObject, Bundle } from "zapier-platform-core";
+
+const SERVER_EVENTS = new Set([
+  "new-server",
+  "server-update",
+  "server-update-downloading",
+  "server-update-installing",
+]);
+
+const perform = async (_z: ZObject, bundle: Bundle) => {
+  const payload = bundle.cleanedRequest as {
+    event?: string;
+    data?: Record<string, unknown>;
+  };
+
+  if (!payload?.data || !payload.event || !SERVER_EVENTS.has(payload.event)) {
+    return [];
+  }
+
+  const d = payload.data;
+  return [
+    {
+      id: `srv-${payload.event}-${Date.now()}`,
+      event: payload.event,
+      version: d.version,
+      name: d.name,
+      status: d.status,
+    },
+  ];
+};
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "srv-server-update-1700000000000",
+    event: "server-update",
+    version: "2.0.0",
+    name: "Photon Server",
+    status: "available",
+  },
+];
+
+export default defineTrigger({
+  key: "server_update_instant",
+  noun: "Server Update",
+
+  display: {
+    label: "Server Update (Instant)",
+    description:
+      "Triggers when your Photon server has an update, is downloading, or installing.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "srv-server-update-1700000000000",
+      event: "server-update",
+      version: "2.0.0",
+      name: "Photon Server",
+      status: "available",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "event", label: "Event Type" },
+      { key: "version", label: "Version" },
+      { key: "name", label: "Server Name" },
+      { key: "status", label: "Status" },
+    ],
+  },
+});

--- a/src/triggers/typingIndicatorInstant.ts
+++ b/src/triggers/typingIndicatorInstant.ts
@@ -1,0 +1,51 @@
+import { defineTrigger } from "zapier-platform-core";
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { subscribe, unsubscribe, makePerform } from "./webhookHelpers.js";
+
+const performList = async (_z: ZObject, _bundle: Bundle) => [
+  {
+    id: "typing-iMessage;-;+11234567890-1700000000000",
+    chatGuid: "iMessage;-;+11234567890",
+    display: true,
+    sender: "+11234567890",
+  },
+];
+
+const perform = makePerform("typing-indicator", (data) => ({
+  id: `typing-${data.chatGuid || data.guid}-${Date.now()}`,
+  chatGuid: data.chatGuid ?? data.guid,
+  display: data.display ?? data.typing,
+  sender: (data.handle as Record<string, unknown>)?.address ?? data.senderAddress,
+}));
+
+export default defineTrigger({
+  key: "typing_indicator_instant",
+  noun: "Typing Indicator",
+
+  display: {
+    label: "Typing Indicator (Instant)",
+    description:
+      "Triggers when someone starts or stops typing in an iMessage conversation.",
+  },
+
+  operation: {
+    type: "hook",
+    perform,
+    performList,
+    performSubscribe: subscribe,
+    performUnsubscribe: unsubscribe,
+
+    sample: {
+      id: "typing-iMessage;-;+11234567890-1700000000000",
+      chatGuid: "iMessage;-;+11234567890",
+      display: true,
+      sender: "+11234567890",
+    },
+    outputFields: [
+      { key: "id", label: "ID" },
+      { key: "chatGuid", label: "Chat GUID" },
+      { key: "display", label: "Is Typing", type: "boolean" },
+      { key: "sender", label: "Sender" },
+    ],
+  },
+});

--- a/src/triggers/webhookHelpers.ts
+++ b/src/triggers/webhookHelpers.ts
@@ -1,0 +1,67 @@
+import type {
+  ZObject,
+  Bundle,
+  WebhookTriggerPerformSubscribe,
+  WebhookTriggerPerformUnsubscribe,
+} from "zapier-platform-core";
+import { normalizeUrl } from "../authentication.js";
+
+export const subscribe = (async (z: ZObject, bundle: Bundle) => {
+  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
+  if (!bridgeUrl) {
+    throw new z.errors.Error(
+      "Webhook Bridge URL is required. Please update your Photon iMessage connection.",
+      "ConfigurationError",
+    );
+  }
+
+  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+  const response = await z.request({
+    url: `${bridgeUrl}/api/webhooks`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {
+      serverUrl,
+      apiKey: bundle.authData.apiKey,
+      webhookUrl: bundle.targetUrl,
+    },
+  });
+
+  return response.data as { id: string; signingSecret: string };
+}) satisfies WebhookTriggerPerformSubscribe;
+
+export const unsubscribe = (async (z: ZObject, bundle: Bundle) => {
+  const bridgeUrl = normalizeUrl(bundle.authData.webhookBridgeUrl as string);
+  if (!bridgeUrl || !bundle.subscribeData?.id) {
+    return {};
+  }
+
+  await z.request({
+    url: `${bridgeUrl}/api/webhooks/${bundle.subscribeData.id}`,
+    method: "DELETE",
+  });
+
+  return {};
+}) satisfies WebhookTriggerPerformUnsubscribe;
+
+/**
+ * Creates a webhook perform function that filters for a specific event and
+ * maps the payload using the provided transform function.
+ */
+export function makePerform<T extends Record<string, unknown>>(
+  eventName: string,
+  transform: (data: Record<string, unknown>) => T,
+) {
+  return async (_z: ZObject, bundle: Bundle): Promise<T[]> => {
+    const payload = bundle.cleanedRequest as {
+      event?: string;
+      data?: Record<string, unknown>;
+    };
+
+    if (!payload?.data || payload.event !== eventName) {
+      return [];
+    }
+
+    return [transform(payload.data)];
+  };
+}


### PR DESCRIPTION
## Summary

Major release making instant webhook triggers the **primary** trigger mechanism via the Photon Webhook Bridge.

- **14 instant triggers** covering every event the webhook bridge forwards:
  - **Messages**: New Message, Message Updated, Message Send Error
  - **Chat events**: Typing Indicator, Chat Read Status Changed
  - **Group management**: Group Name Changed, Participant Added/Removed/Left, Group Icon Changed
  - **Scheduled messages**: Created/Updated/Deleted/Sent/Error (unified trigger)
  - **Other**: FaceTime Call Status, Find My Location, Server Updates
- **Webhook Bridge URL** is now a **required** auth field
- **Polling `new_message`** trigger is now **hidden** (fallback only)
- Shared `webhookHelpers.ts` with reusable subscribe/unsubscribe/perform factory
- All hook triggers include `performList` for Zapier D006 compliance
- **25/25 validation checks pass, 0 publishing warnings**
- Version bumped to **2.0.0**, pushed to Zapier

## Test plan
- [ ] Connect account with Webhook Bridge URL
- [ ] Create Zaps for each instant trigger and verify subscription is created
- [ ] Send test iMessage → verify New Message (Instant) fires
- [ ] Edit message → verify Message Updated fires
- [ ] Start typing → verify Typing Indicator fires
- [ ] Rename group → verify Group Name Changed fires
- [ ] Add/remove participant → verify respective triggers fire
- [ ] Turn off Zaps and verify subscriptions are cleaned up
- [ ] Verify hidden polling trigger still works when accessed directly