### PR TITLE
feat: enforce inbound-first policy on all outbound actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-imessage",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Photon iMessage is a powerful iMessage automation platform that lets you send, receive, and manage iMessages programmatically.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/creates/addParticipant.ts
+++ b/src/creates/addParticipant.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -23,6 +24,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}/participant/add`,
     method: "POST",

--- a/src/creates/createGroupChat.ts
+++ b/src/creates/createGroupChat.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundForAddresses } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -46,6 +47,8 @@ const perform = (async (z, bundle) => {
     .split(",")
     .map((a: string) => a.trim())
     .filter(Boolean);
+
+  await requireInboundForAddresses(z, bundle, addresses);
 
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/new`,

--- a/src/creates/createPoll.ts
+++ b/src/creates/createPoll.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -32,6 +33,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const options = bundle.inputData.options
     .split(",")
     .map((o: string) => o.trim())

--- a/src/creates/deleteChat.ts
+++ b/src/creates/deleteChat.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -17,6 +18,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}`,
     method: "DELETE",

--- a/src/creates/inboundCheck.ts
+++ b/src/creates/inboundCheck.ts
@@ -1,0 +1,102 @@
+import type { ZObject, Bundle } from "zapier-platform-core";
+import { normalizeUrl } from "../authentication.js";
+
+const POLICY_ERROR =
+  "Photon Inbound-First Policy: No inbound message found for this chat. " +
+  "You can only send to conversations where you have received at least one " +
+  "message first. This protects your server from being flagged or banned. " +
+  "Contact the Photon team if you need special access for outbound-first messaging.";
+
+/**
+ * Checks that at least one inbound (not from me) message exists in the given
+ * chat before allowing an outbound action.  Throws a user-friendly error if
+ * the chat has no inbound history.
+ */
+export async function requireInboundMessage(
+  z: ZObject,
+  bundle: Bundle,
+  chatGuid: string,
+): Promise<void> {
+  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+
+  const response = await z.request<{
+    data?: Array<{ isFromMe: boolean }>;
+  }>({
+    url: `${serverUrl}/api/v1/message/query`,
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: {
+      chatGuid,
+      limit: 1,
+      where: [{ statement: "message.is_from_me = :value", args: { value: 0 } }],
+    },
+    skipThrowForStatus: true,
+  });
+
+  if (response.status >= 400) {
+    // Fallback: if the query endpoint doesn't support the where clause, try
+    // fetching recent messages and checking manually.
+    const fallback = await z.request<{
+      data?: Array<{ isFromMe: boolean; is_from_me?: number }>;
+    }>({
+      url: `${serverUrl}/api/v1/message/query`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { chatGuid, limit: 50, sort: "DESC" },
+    });
+
+    const messages = fallback.data?.data ?? [];
+    const hasInbound = messages.some(
+      (m) => m.isFromMe === false || m.is_from_me === 0,
+    );
+
+    if (!hasInbound) {
+      throw new z.errors.Error(POLICY_ERROR, "InboundFirstPolicy");
+    }
+    return;
+  }
+
+  const messages = response.data?.data ?? [];
+  if (messages.length === 0) {
+    throw new z.errors.Error(POLICY_ERROR, "InboundFirstPolicy");
+  }
+}
+
+/**
+ * For createGroupChat: checks that at least one of the provided addresses
+ * has an existing chat with inbound messages.
+ */
+export async function requireInboundForAddresses(
+  z: ZObject,
+  bundle: Bundle,
+  addresses: string[],
+): Promise<void> {
+  const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+
+  for (const address of addresses) {
+    const chatGuid = `iMessage;-;${address}`;
+    const response = await z.request<{
+      data?: Array<{ isFromMe: boolean; is_from_me?: number }>;
+    }>({
+      url: `${serverUrl}/api/v1/message/query`,
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: { chatGuid, limit: 5, sort: "DESC" },
+      skipThrowForStatus: true,
+    });
+
+    const messages = response.data?.data ?? [];
+    const hasInbound = messages.some(
+      (m) => m.isFromMe === false || m.is_from_me === 0,
+    );
+
+    if (hasInbound) return;
+  }
+
+  throw new z.errors.Error(
+    "Photon Inbound-First Policy: None of the provided addresses have inbound " +
+      "message history. You can only create group chats with contacts who have " +
+      "messaged you first. Contact the Photon team for special access.",
+    "InboundFirstPolicy",
+  );
+}

--- a/src/creates/markChatRead.ts
+++ b/src/creates/markChatRead.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -17,6 +18,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}/read`,
     method: "POST",

--- a/src/creates/reactMessage.ts
+++ b/src/creates/reactMessage.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -38,6 +39,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/message/react`,
     method: "POST",

--- a/src/creates/removeParticipant.ts
+++ b/src/creates/removeParticipant.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -23,6 +24,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}/participant/remove`,
     method: "POST",

--- a/src/creates/renameGroupChat.ts
+++ b/src/creates/renameGroupChat.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -22,6 +23,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}`,
     method: "PUT",

--- a/src/creates/scheduleMessage.ts
+++ b/src/creates/scheduleMessage.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -45,6 +46,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const scheduledFor = new Date(bundle.inputData.scheduledFor).getTime();
 
   const response = await z.request({

--- a/src/creates/sendAttachment.ts
+++ b/src/creates/sendAttachment.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -39,6 +40,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const fileResponse = await z.request({
     url: bundle.inputData.fileUrl,
     raw: true,

--- a/src/creates/sendMessage.ts
+++ b/src/creates/sendMessage.ts
@@ -4,6 +4,7 @@ import {
   type CreatePerform,
 } from "zapier-platform-core";
 import { randomUUID } from "node:crypto";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -48,6 +49,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/message/text`,
     method: "POST",

--- a/src/creates/sendSticker.ts
+++ b/src/creates/sendSticker.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -48,6 +49,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const fileResponse = await z.request({
     url: bundle.inputData.stickerUrl,
     raw: true,

--- a/src/creates/setChatBackground.ts
+++ b/src/creates/setChatBackground.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -24,6 +25,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const fileResponse = await z.request({
     url: bundle.inputData.imageUrl,
     raw: true,

--- a/src/creates/setGroupIcon.ts
+++ b/src/creates/setGroupIcon.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -23,6 +24,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const fileResponse = await z.request({
     url: bundle.inputData.imageUrl,
     raw: true,

--- a/src/creates/shareContactCard.ts
+++ b/src/creates/shareContactCard.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -17,6 +18,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/contact/share`,
     method: "POST",

--- a/src/creates/startTyping.ts
+++ b/src/creates/startTyping.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -17,6 +18,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/chat/${encodeURIComponent(bundle.inputData.chatGuid)}/typing`,
     method: "POST",

--- a/src/creates/votePoll.ts
+++ b/src/creates/votePoll.ts
@@ -3,6 +3,7 @@ import {
   defineInputFields,
   type CreatePerform,
 } from "zapier-platform-core";
+import { requireInboundMessage } from "./inboundCheck.js";
 
 const inputFields = defineInputFields([
   {
@@ -31,6 +32,7 @@ const inputFields = defineInputFields([
 ]);
 
 const perform = (async (z, bundle) => {
+  await requireInboundMessage(z, bundle, bundle.inputData.chatGuid);
   const response = await z.request({
     url: `${bundle.authData.serverUrl}/api/v1/poll/vote`,
     method: "POST",


### PR DESCRIPTION
## Summary
- Adds **Photon Inbound-First Policy** enforcement across all 17 outbound create actions
- Before any outbound operation (send message, add participant, create group, etc.), the system queries the chat for inbound messages
- If no inbound message is found, the action is blocked with a clear error: *"Photon Inbound-First Policy: No inbound message found for this chat..."*
- This protects servers from being flagged or banned by ensuring conversations are always initiated by the other party

### How it works
- `requireInboundMessage(z, bundle, chatGuid)` — queries `/api/v1/message/query` for the chat and checks for at least one `isFromMe: false` message
- `requireInboundForAddresses(z, bundle, addresses)` — checks each address's DM chat for inbound history (used by Create Group Chat)
- **Exempt**: `editMessage` and `unsendMessage` (operate on your own existing messages, no new outbound contact)

### Creates protected (17)
sendMessage, scheduleMessage, reactMessage, sendAttachment, sendSticker, addParticipant, removeParticipant, renameGroupChat, deleteChat, markChatRead, startTyping, createPoll, votePoll, shareContactCard, setChatBackground, setGroupIcon, createGroupChat

- Version bumped to **2.1.0**, pushed to Zapier

## Test plan
- [ ] Attempt to send a message to a chat with no inbound messages → expect policy error
- [ ] Attempt to send a message to a chat with prior inbound messages → expect success
- [ ] Attempt to create a group chat with addresses that have no inbound history → expect policy error
- [ ] Attempt to create a group chat where at least one address has inbound history → expect success
- [ ] Verify editMessage and unsendMessage still work without the check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat operations now require receiving at least one message in a conversation first. This applies to sending messages, creating group chats, reactions, participant management, scheduling messages, sending attachments, stickers, and other operations.

* **Chores**
  * Version updated to 2.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->