### PR TITLE
refactor: replace technical GUID labels with user-friendly field names

### DIFF
--- a/src/creates/addParticipant.ts
+++ b/src/creates/addParticipant.ts
@@ -8,14 +8,15 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Group Chat",
     type: "string",
     required: true,
-    helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    helpText:
+      "The group chat identifier. Usually mapped from a trigger step.",
   },
   {
     key: "address",
-    label: "Participant Address",
+    label: "Phone Number or Email",
     type: "string",
     required: true,
     helpText: "Phone number or email to add, e.g. +1234567890",

--- a/src/creates/createPoll.ts
+++ b/src/creates/createPoll.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "title",

--- a/src/creates/deleteChat.ts
+++ b/src/creates/deleteChat.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
 ]);
 

--- a/src/creates/markChatRead.ts
+++ b/src/creates/markChatRead.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
 ]);
 

--- a/src/creates/reactMessage.ts
+++ b/src/creates/reactMessage.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "messageGuid",

--- a/src/creates/removeParticipant.ts
+++ b/src/creates/removeParticipant.ts
@@ -8,14 +8,15 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Group Chat",
     type: "string",
     required: true,
-    helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    helpText:
+      "The group chat identifier. Usually mapped from a trigger step.",
   },
   {
     key: "address",
-    label: "Participant Address",
+    label: "Phone Number or Email",
     type: "string",
     required: true,
     helpText: "Phone number or email to remove, e.g. +1234567890",

--- a/src/creates/renameGroupChat.ts
+++ b/src/creates/renameGroupChat.ts
@@ -8,10 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Group Chat",
     type: "string",
     required: true,
-    helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    helpText:
+      "The group chat identifier. Usually mapped from a trigger step.",
   },
   {
     key: "displayName",

--- a/src/creates/scheduleMessage.ts
+++ b/src/creates/scheduleMessage.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "message",

--- a/src/creates/sendAttachment.ts
+++ b/src/creates/sendAttachment.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "fileUrl",

--- a/src/creates/sendMessage.ts
+++ b/src/creates/sendMessage.ts
@@ -9,11 +9,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "message",

--- a/src/creates/sendSticker.ts
+++ b/src/creates/sendSticker.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "stickerUrl",

--- a/src/creates/setChatBackground.ts
+++ b/src/creates/setChatBackground.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "imageUrl",

--- a/src/creates/setGroupIcon.ts
+++ b/src/creates/setGroupIcon.ts
@@ -8,10 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Group Chat",
     type: "string",
     required: true,
-    helpText: "The group chat GUID, e.g. iMessage;+;chat123",
+    helpText:
+      "The group chat identifier. Usually mapped from a trigger step.",
   },
   {
     key: "imageUrl",

--- a/src/creates/shareContactCard.ts
+++ b/src/creates/shareContactCard.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
 ]);
 

--- a/src/creates/startTyping.ts
+++ b/src/creates/startTyping.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
 ]);
 

--- a/src/creates/votePoll.ts
+++ b/src/creates/votePoll.ts
@@ -8,11 +8,11 @@ import { requireInboundMessage } from "./inboundCheck.js";
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Chat",
     type: "string",
     required: true,
     helpText:
-      "e.g. iMessage;-;+1234567890 for a DM or iMessage;+;chat123 for a group",
+      "Phone number, email, or group chat ID. Usually mapped from a trigger step (e.g. +1234567890 or a Chat GUID).",
   },
   {
     key: "pollMessageGuid",

--- a/src/searches/findMessages.ts
+++ b/src/searches/findMessages.ts
@@ -21,7 +21,7 @@ const inputFields = defineInputFields([
   },
   {
     key: "chatGuid",
-    label: "Chat GUID (optional)",
+    label: "Chat (optional)",
     type: "string",
     required: false,
   },

--- a/src/searches/getChatParticipants.ts
+++ b/src/searches/getChatParticipants.ts
@@ -7,10 +7,11 @@ import {
 const inputFields = defineInputFields([
   {
     key: "chatGuid",
-    label: "Chat GUID",
+    label: "Group Chat",
     type: "string",
     required: true,
-    helpText: "The chat GUID, e.g. iMessage;+;chat123 for a group",
+    helpText:
+      "The group chat identifier. Usually mapped from a trigger step.",
   },
 ]);
 


### PR DESCRIPTION
## Summary
- Rename "Chat GUID" to "Chat" for 12 general messaging actions with clear helpText ("Phone number, email, or group chat ID")
- Rename "Chat GUID" to "Group Chat" for 5 group-only actions (add/remove participant, rename, set icon, get participants)
- Rename "Participant Address" to "Phone Number or Email"
- Rename search field "Chat GUID (optional)" to "Chat (optional)"

## Test plan
- [ ] Zapier editor shows "Chat" label for send message, react, etc.
- [ ] Zapier editor shows "Group Chat" for add/remove participant, rename, etc.
- [ ] Zapier editor shows "Phone Number or Email" for participant fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified input field labels and help text across chat-related actions and searches for improved user guidance. Chat identifier fields now provide clearer descriptions of acceptable formats (phone numbers, emails, or chat IDs) and explain how they map from trigger steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->