### PR TITLE
v3.0.6: Remove iMessage Action, version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zapier-imessage",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "iMessage by Photon is a powerful iMessage automation platform that lets you send, receive, and manage iMessages programmatically.",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import newMessageInstant from "./triggers/newMessageInstant.js";
 import messageUpdatedInstant from "./triggers/messageUpdatedInstant.js";
 
 // Creates – core set
-import performAction from "./creates/performAction.js";
 import sendMessage from "./creates/sendMessage.js";
 import scheduleMessage from "./creates/scheduleMessage.js";
 import sendAttachment from "./creates/sendAttachment.js";
@@ -64,7 +63,6 @@ export default defineApp({
   },
 
   creates: {
-    [performAction.key]: performAction,
     [sendMessage.key]: sendMessage,
     [scheduleMessage.key]: scheduleMessage,
     [sendAttachment.key]: sendAttachment,


### PR DESCRIPTION
- Remove perform_action (iMessage Action) from creates.
- Bump version to 3.0.6.