### PR TITLE
feat: fully automatic webhook signing (no manual signing secret)

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -6,22 +6,34 @@ import type {
 } from "zapier-platform-core";
 
 /**
- * Strips any trailing slashes from a URL and collapses double slashes in the
- * path portion.  This is applied both in the beforeRequest middleware (for all
- * requests) and explicitly inside the auth test perform function (to guard
- * against the Zapier hosted-platform behaviour where the {{curlies}} template
- * is resolved by the backend *before* the app's beforeRequest chain runs,
- * meaning our middleware never gets a chance to normalise the URL).
+ * Canonical URL for the Photon Webhook Bridge. When a Zap with an instant
+ * trigger turns ON, performSubscribe POSTs here with { serverUrl, apiKey,
+ * webhookUrl } and gets back { id, signingSecret }. Fully automatic.
+ * @see https://webhook.photon.codes/
+ */
+export const WEBHOOK_BRIDGE_URL = "https://webhook.photon.codes";
+
+/**
+ * Strips trailing slashes and collapses double slashes in the path portion,
+ * leaving the protocol double-slash intact.
  */
 export const normalizeUrl = (url: string): string =>
   (url || "")
-    // Strip trailing slashes from the whole URL first
     .replace(/\/+$/, "")
-    // Collapse any double (or more) slashes in the path, but leave the
-    // protocol double-slash (https://) intact
     .replace(/(https?:\/\/)\/+/g, "$1")
     .replace(/([^:])\/\/+/g, "$1/");
 
+/** True when the URL points to the webhook bridge (credentials go in body, not header). */
+function isBridgeRequest(url: string): boolean {
+  const normalized = normalizeUrl(url);
+  const bridge = normalizeUrl(WEBHOOK_BRIDGE_URL);
+  return normalized === bridge || normalized.startsWith(bridge + "/");
+}
+
+/**
+ * Adds X-API-Key to Photon server requests. Bridge requests are skipped
+ * because the bridge receives credentials in the POST body instead.
+ */
 export const addApiKeyToHeader: BeforeRequestMiddleware = (
   request,
   _z,
@@ -30,7 +42,9 @@ export const addApiKeyToHeader: BeforeRequestMiddleware = (
   if (request.url) {
     request.url = normalizeUrl(request.url);
   }
-
+  if (request.url && isBridgeRequest(request.url)) {
+    return request;
+  }
   request.headers = {
     ...request.headers,
     "X-API-Key": bundle.authData.apiKey as string,
@@ -38,104 +52,58 @@ export const addApiKeyToHeader: BeforeRequestMiddleware = (
   return request;
 };
 
-export const WEBHOOK_BRIDGE_URL = "https://webhooks.photon.codes";
-
 /**
- * Credentials flow: user enters Endpoint (server URL) + API Key. When they use
- * a trigger and turn the Zap on, we take these plus Zapier's webhook URL (the
- * endpoint that receives events), POST to webhooks.photon.codes, get the
- * signing secret back, and use it to verify incoming webhooks. All in the background.
+ * Auth test: validate Endpoint + API Key against the Photon server.
+ * No bridge interaction here -- the bridge is called automatically in
+ * performSubscribe when a Zap turns on.
  */
 const authTest = async (z: ZObject, bundle: Bundle) => {
   const baseUrl = normalizeUrl(bundle.authData.serverUrl as string);
-  const bridgeUrl = normalizeUrl(
-    (bundle.authData.webhookBridgeUrl as string) || WEBHOOK_BRIDGE_URL,
-  );
 
-  const serverResponse = await z.request({
+  const response = await z.request({
     url: `${baseUrl}/api/v1/server/info`,
     method: "GET",
     skipThrowForStatus: true,
   });
 
-  if (serverResponse.status === 401 || serverResponse.status === 403) {
+  if (response.status === 401 || response.status === 403) {
     throw new z.errors.Error(
-      "Authentication failed: invalid API key.",
+      "Invalid API key.",
       "AuthenticationError",
-      serverResponse.status,
+      response.status,
     );
   }
 
-  if (serverResponse.status === 404) {
+  if (response.status === 404) {
     throw new z.errors.Error(
-      `Could not reach the Photon server at "${baseUrl}". Check that the Server URL is correct and the server is running.`,
+      `Cannot reach Photon server at "${baseUrl}". Check the Endpoint URL and that the server is running.`,
       "NotFoundError",
-      serverResponse.status,
+      response.status,
     );
   }
 
-  if (serverResponse.status >= 400) {
+  if (response.status >= 400) {
     throw new z.errors.Error(
-      `Server returned an unexpected error (HTTP ${serverResponse.status}). Verify your Server URL and API Key.`,
+      `Server error (HTTP ${response.status}). Verify Endpoint and API Key.`,
       "ApiError",
-      serverResponse.status,
+      response.status,
     );
   }
 
-  const apiKey = bundle.authData.apiKey as string;
-  const testWebhookUrl = "https://zapier-connection-test.invalid";
-  const bridgeSubscribe = await z.request({
-    url: `${bridgeUrl}/api/webhooks`,
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: {
-      serverUrl: baseUrl,
-      apiKey,
-      webhookUrl: testWebhookUrl,
-    },
-    skipThrowForStatus: true,
-  });
-
-  if (bridgeSubscribe.status >= 200 && bridgeSubscribe.status < 300) {
-    const data = bridgeSubscribe.data as { id?: string };
-    if (data?.id) {
-      await z.request({
-        url: `${bridgeUrl}/api/webhooks/${data.id}`,
-        method: "DELETE",
-        skipThrowForStatus: true,
-      });
-    }
-  } else if (bridgeSubscribe.status === 404) {
+  const body = response.data;
+  const bodyStr = typeof body === "string" ? body : JSON.stringify(body ?? "");
+  if (
+    bodyStr.toLowerCase().includes("github") ||
+    (typeof body === "string" && body.trimStart().startsWith("<!"))
+  ) {
     throw new z.errors.Error(
-      `Webhook Bridge at "${bridgeUrl}" does not expose POST /api/webhooks. ` +
-        "Use a bridge that supports programmatic webhook registration (e.g. github.com/photon-hq/webhook).",
-      "NotFoundError",
-      404,
-    );
-  } else if (bridgeSubscribe.status === 401 || bridgeSubscribe.status === 403) {
-    throw new z.errors.Error(
-      "Webhook Bridge rejected the request. Check that your Server URL and API Key are correct.",
-      "AuthenticationError",
-      bridgeSubscribe.status,
-    );
-  } else if (bridgeSubscribe.status >= 400) {
-    const msg =
-      (bridgeSubscribe.data as { message?: string })?.message ||
-      `Bridge returned HTTP ${bridgeSubscribe.status}.`;
-    throw new z.errors.Error(
-      `Webhook Bridge error: ${msg} Ensure the bridge URL and your credentials are correct.`,
+      "Endpoint URL looks wrong (got a web page). Use your Photon iMessage server URL only (e.g. https://yourserver.imsgd.photon.codes).",
       "ApiError",
-      bridgeSubscribe.status,
+      400,
     );
   }
 
-  return {
-    ...(typeof serverResponse.data === "object" && serverResponse.data !== null
-      ? serverResponse.data
-      : {}),
-    serverUrl: baseUrl,
-    webhookBridgeUrl: bridgeUrl,
-  };
+  return { serverUrl: baseUrl };
 };
 
 const authentication: Authentication = {
@@ -148,7 +116,7 @@ const authentication: Authentication = {
       required: true,
       default: "https://example.imsgd.photon.codes",
       helpText:
-        "Your Photon iMessage server URL. We use this plus your API key to register with webhooks.photon.codes so events can reach your Zaps.",
+        "Your Photon iMessage server URL (e.g. https://yourserver.imsgd.photon.codes). Webhook configuration and signing are handled automatically when you turn on a Zap with an instant trigger.",
     },
     {
       key: "apiKey",
@@ -157,10 +125,9 @@ const authentication: Authentication = {
       required: true,
       computed: false,
       helpText:
-        "API key for the endpoint above. When you turn on a Zap, we send this and Zapier's webhook URL to webhooks.photon.codes and get a signing secret to verify deliveries.",
+        "API key for your Photon server.",
     },
   ],
-  // Use a function perform so we control URL normalisation and error messages.
   test: authTest,
   connectionLabel: "{{bundle.authData.serverUrl}}",
 };

--- a/src/triggers/messageUpdatedInstant.ts
+++ b/src/triggers/messageUpdatedInstant.ts
@@ -63,7 +63,7 @@ export default defineTrigger({
   display: {
     label: "Message Updated",
     description:
-      "Triggers when an iMessage is edited or updated on your Photon server via the Webhook Bridge. Test uses recent messages; when the Zap is ON, runs are delivered in real time by webhook.",
+      "Triggers when an iMessage is edited or updated. Webhook configuration and signing are handled automatically via https://webhook.photon.codes when the Zap turns on.",
   },
 
   operation: {

--- a/src/triggers/newMessageInstant.ts
+++ b/src/triggers/newMessageInstant.ts
@@ -63,7 +63,7 @@ export default defineTrigger({
   display: {
     label: "New Message Received",
     description:
-      "Triggers when a new iMessage is received on your Photon server via the Webhook Bridge. In the editor, 'Find new records' uses your server for test data; when the Zap is ON, runs are delivered in real time by webhook.",
+      "Triggers when a new iMessage is received. Webhook configuration and signing are handled automatically via https://webhook.photon.codes when the Zap turns on.",
   },
 
   operation: {

--- a/src/triggers/webhookHelpers.ts
+++ b/src/triggers/webhookHelpers.ts
@@ -1,17 +1,15 @@
 /**
- * Webhook trigger lifecycle (automatic when Zap is ON). Bridge: github.com/photon-hq/webhook.
+ * Webhook trigger lifecycle for https://webhook.photon.codes
  *
- * 1) Subscribe (Zap ON): We POST to bridge with { serverUrl, apiKey, webhookUrl }.
- *    Bridge must return { id, signingSecret }. Bridge generates the signing secret;
- *    we store it and use it only to verify incoming requests. If the bridge only
- *    has a web form today, it needs POST /api/webhooks (and DELETE /api/webhooks/:id)
- *    so Zapier can subscribe without manual steps.
+ * 1) Subscribe (Zap ON): POST to bridge /api/webhooks with
+ *    { serverUrl, apiKey, webhookUrl }. Bridge returns { id, signingSecret }.
+ *    Both are stored in subscribeData automatically by Zapier.
  *
- * 2) Bridge forwards: POST to webhookUrl with body { event, data }, headers
- *    X-Photon-Signature (v0=<hmac-hex>), X-Photon-Timestamp (unix sec).
- *    HMAC = HMAC-SHA256(signingSecret, "v0:" + timestamp + ":" + rawBody). We verify.
+ * 2) Incoming webhooks: Bridge POSTs to Zapier with body { event, data },
+ *    headers X-Photon-Signature (v0=<hmac-hex>), X-Photon-Timestamp (unix sec).
+ *    We verify with verifySignature() using subscribeData.signingSecret.
  *
- * 3) Unsubscribe (Zap OFF): We DELETE bridge /api/webhooks/:id.
+ * 3) Unsubscribe (Zap OFF): DELETE bridge /api/webhooks/:id.
  */
 import { createHmac, timingSafeEqual } from "node:crypto";
 import type {
@@ -25,9 +23,9 @@ import { normalizeUrl, WEBHOOK_BRIDGE_URL } from "../authentication.js";
 const MAX_TIMESTAMP_DRIFT_SECONDS = 300;
 
 /**
- * Verifies the HMAC-SHA256 signature on an incoming webhook payload from the
- * Photon Webhook Bridge.  Returns true when the signature is valid or when
- * no signing secret is available (graceful degradation for older subscriptions).
+ * Verifies the HMAC-SHA256 signature on an incoming webhook payload.
+ * Signature format: v0=<hex>
+ * Signed base string: v0:<timestamp>:<rawBody>
  */
 export function verifySignature(
   rawBody: string,
@@ -35,7 +33,8 @@ export function verifySignature(
   signature: string | undefined,
   timestamp: string | undefined,
 ): boolean {
-  if (!signingSecret || !signature || !timestamp) return true;
+  if (!signingSecret) return false;
+  if (!signature || !timestamp) return false;
 
   const ts = Number(timestamp);
   if (Number.isNaN(ts)) return false;
@@ -54,10 +53,9 @@ export function verifySignature(
 }
 
 export const subscribe = (async (z: ZObject, bundle: Bundle) => {
-  const bridgeUrl = normalizeUrl(
-    (bundle.authData.webhookBridgeUrl as string) || WEBHOOK_BRIDGE_URL,
-  );
+  const bridgeUrl = normalizeUrl(WEBHOOK_BRIDGE_URL);
   const serverUrl = normalizeUrl(bundle.authData.serverUrl as string);
+
   const response = await z.request({
     url: `${bridgeUrl}/api/webhooks`,
     method: "POST",
@@ -73,13 +71,11 @@ export const subscribe = (async (z: ZObject, bundle: Bundle) => {
 }) satisfies WebhookTriggerPerformSubscribe;
 
 export const unsubscribe = (async (z: ZObject, bundle: Bundle) => {
-  const bridgeUrl = normalizeUrl(
-    (bundle.authData.webhookBridgeUrl as string) || WEBHOOK_BRIDGE_URL,
-  );
   if (!bundle.subscribeData?.id) {
     return {};
   }
 
+  const bridgeUrl = normalizeUrl(WEBHOOK_BRIDGE_URL);
   await z.request({
     url: `${bridgeUrl}/api/webhooks/${bundle.subscribeData.id}`,
     method: "DELETE",
@@ -89,25 +85,40 @@ export const unsubscribe = (async (z: ZObject, bundle: Bundle) => {
 }) satisfies WebhookTriggerPerformUnsubscribe;
 
 /**
- * Verifies the webhook signature from a bundle, throwing on failure.
- * Use this in custom perform functions that don't go through `makePerform`.
+ * Returns the signing secret from subscribeData (set during performSubscribe).
+ * Throws if missing -- this means the Zap wasn't properly subscribed.
+ */
+export function getSigningSecret(bundle: Bundle): string {
+  const sub = (bundle.subscribeData ?? {}) as Record<string, unknown>;
+  const secret = sub.signingSecret as string | undefined;
+  if (!secret) {
+    throw new Error("MissingSigningSecret");
+  }
+  return secret;
+}
+
+/**
+ * Verifies the webhook signature from the bundle; throws on failure.
  */
 export function assertValidSignature(z: ZObject, bundle: Bundle): void {
   const headers = (bundle.rawRequest?.headers ?? {}) as Record<string, string>;
   const rawBody = bundle.rawRequest?.content ?? "";
-  const subData = (bundle.subscribeData ?? {}) as Record<string, unknown>;
-  const signingSecret = subData.signingSecret as string | undefined;
-
-  if (
-    !verifySignature(
-      rawBody,
-      signingSecret,
-      headers["x-photon-signature"] ?? headers["X-Photon-Signature"],
-      headers["x-photon-timestamp"] ?? headers["X-Photon-Timestamp"],
-    )
-  ) {
+  let signingSecret: string;
+  try {
+    signingSecret = getSigningSecret(bundle);
+  } catch {
     throw new z.errors.Error(
-      "Invalid webhook signature — request rejected.",
+      "Signing secret not found. This Zap may not be properly subscribed. Try turning the Zap off and on again.",
+      "MissingSigningSecret",
+      403,
+    );
+  }
+  const sig =
+    headers["x-photon-signature"] ?? headers["X-Photon-Signature"];
+  const ts = headers["x-photon-timestamp"] ?? headers["X-Photon-Timestamp"];
+  if (!verifySignature(rawBody, signingSecret, sig, ts)) {
+    throw new z.errors.Error(
+      "Invalid or missing webhook signature. Ensure the bridge sends X-Photon-Signature and X-Photon-Timestamp headers.",
       "SignatureError",
       403,
     );


### PR DESCRIPTION
## Summary

- **Authentication simplified to 2 fields**: Endpoint + API Key only. Signing secret and bridge URL fields removed from the credentials page.
- **Automatic webhook registration**: When a Zap with an instant trigger turns ON, `performSubscribe` POSTs to `https://webhook.photon.codes/api/webhooks` with `{ serverUrl, apiKey, webhookUrl }` and receives `{ id, signingSecret }` back — stored automatically in `subscribeData`.
- **Signature verification uses subscribeData only**: No more fallback to `authData.signingSecret`. If the signing secret is missing, the error tells the user to toggle the Zap off/on.

## Changes

| File | What changed |
|------|-------------|
| `src/authentication.ts` | 2 fields (Endpoint, API Key). Auth test only validates server. Bridge probe removed. `addApiKeyToHeader` skips bridge URLs. |
| `src/triggers/webhookHelpers.ts` | Manual subscribe fallback removed. Bridge URL hardcoded. `getSigningSecret()` reads only from `subscribeData`. |
| `src/triggers/newMessageInstant.ts` | Description simplified. |
| `src/triggers/messageUpdatedInstant.ts` | Description simplified. |

## Flow

1. User enters **Endpoint** + **API Key** → auth test validates against Photon server
2. User adds trigger, turns Zap ON → `performSubscribe` calls `webhook.photon.codes` → gets signing secret automatically
3. Bridge sends webhooks → HMAC-SHA256 verified with `subscribeData.signingSecret`
4. Zap OFF → `performUnsubscribe` deletes the bridge webhook

## Test plan

- [ ] Connect with valid Endpoint + API Key — should succeed
- [ ] Connect with invalid API key — should fail with clear error
- [ ] Turn on Zap with New Message Received trigger — subscribe should succeed and store signing secret
- [ ] Receive a webhook — signature verification should pass
- [ ] Turn off Zap — unsubscribe should delete the bridge webhook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Webhook configuration and signing are now handled automatically when activating triggers.
  * Simplified authentication setup with streamlined webhook bridge handling.
  * Updated error messages for clearer endpoint reachability diagnostics.
  * Enhanced webhook signature verification with stricter validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->